### PR TITLE
Don't declare stb as a dependency, use vendored headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,6 @@ project('sfml', 'cpp',
 
 cpp = meson.get_compiler('cpp')
 
-stb_dep = dependency('stb')
 openal_dep = dependency('openal')
 thread_dep = dependency('threads')
 gl_dep = dependency('gl')

--- a/src/SFML/Graphics/meson.build
+++ b/src/SFML/Graphics/meson.build
@@ -40,10 +40,12 @@ graphics_sources += files(
     'RenderTextureImplDefault.cpp',
 )
 
+stb = include_directories('../../../extlibs/headers/stb_image')
+
 graphics_lib = library('sfml-graphics',
     graphics_sources,
     cpp_args: get_option('default_library') == 'shared' ? ['-DSFML_GRAPHICS_EXPORTS'] : ['-DSFML_STATIC'],
-    include_directories: [pub_inc, priv_inc],
+    include_directories: [pub_inc, priv_inc, stb],
     link_with: [window_lib, system_lib],
-    dependencies: [gl_dep, stb_dep, freetype_dep],
+    dependencies: [gl_dep, freetype_dep],
 )


### PR DESCRIPTION
stb is a header-only dependency. Projects vendor the header in their
sources. The library isn't (most of the time) installed system-wide.
SFML doesn't use the stb system headers, and this is documented:

> The stb_image_* header in the extlibs directory are used regardless
> of this option.

https://www.sfml-dev.org/tutorials/2.5/compile-with-cmake.php (look
for SFML_USE_SYSTEM_DEPS).

Fix #2. (edit: sorry messed the cross-ref)